### PR TITLE
is it a binding loop?

### DIFF
--- a/examples/touch/glacier-components.qml
+++ b/examples/touch/glacier-components.qml
@@ -177,14 +177,14 @@ ApplicationWindow {
                     anchors.horizontalCenter: (parent==undefined) ? undefined : parent.horizontalCenter;
                     text: qsTr("Black theme")
                     onClicked: {
-                        Theme.loadTheme("/usr/lib/qt5/qml/QtQuick/Controls/Styles/Nemo/themes/glacier_black.json")
+                        Theme.loadTheme("/usr/lib/qt/qml/QtQuick/Controls/Styles/Nemo/themes/glacier_black.json")
                     }
                 },
                 Button {
                     anchors.horizontalCenter: (parent==undefined) ? undefined : parent.horizontalCenter;
                     text: qsTr("White theme")
                     onClicked: {
-                        Theme.loadTheme("/usr/lib/qt5/qml/QtQuick/Controls/Styles/Nemo/themes/glacier_white.json")
+                        Theme.loadTheme("/usr/lib/qt/qml/QtQuick/Controls/Styles/Nemo/themes/glacier_white.json")
                     }
                 },
                 RowLayout {

--- a/src/controls/qml/Header.qml
+++ b/src/controls/qml/Header.qml
@@ -326,8 +326,6 @@ Item {
 
         ColumnLayout {
             id: drawer
-            width: parent.width
-            height: parent.height
 
             //NOTE: if you set the spacing to something != 0 then you have to rewrite the logic which handles drawer speedbumps,
             //which currently relies on "spacing" being 0


### PR DESCRIPTION
The drawer.height is not correct when the `drawer.height: parent.height` set. 

In the same time, there is a Binding:
```
        Binding on height {
            restoreMode: Binding.RestoreBinding
            value: drawer.height
            when: appWindow.isUiPortrait
        }
```

I am not sure what how the variable is set, but after proposed change, the behaviour in landscape mode changes from broken layout into something sane:

![Screenshot_manjaro_2021-06-02_21:34:39](https://user-images.githubusercontent.com/6171637/120541697-7bb2a180-c3ea-11eb-992b-b3486969f1c5.png)


![Screenshot_manjaro_2021-06-02_21:32:12](https://user-images.githubusercontent.com/6171637/120541699-7ce3ce80-c3ea-11eb-866e-fc3c6b26386b.png)

I believe the portrait mode behaves better as well