### PR TITLE
ListViewItemWithActions: add selected property

### DIFF
--- a/examples/touch/content/ListViewPage.qml
+++ b/examples/touch/content/ListViewPage.qml
@@ -93,6 +93,9 @@ Page {
                 }
 
             ]
+            onClicked: {
+                selected = !selected
+            }
         }
         section.property: "size"
     }

--- a/src/controls/qml/ListViewItemWithActions.qml
+++ b/src/controls/qml/ListViewItemWithActions.qml
@@ -48,6 +48,7 @@ Item {
     property bool showNext: true
     property bool iconVisible: true
     property bool iconColorized: true
+    property bool selected: false
 
     property bool showActions: true
 
@@ -98,7 +99,7 @@ Item {
         id: listArea
         width: root.width
         height: root.height
-        color: "transparent"
+        color: selected ? Theme.accentColor :"transparent"
 
         Behavior on x{
             NumberAnimation { duration: 200}


### PR DESCRIPTION
The selection seems to be required by other tools e.g. filemuncher or contacts.

![Screenshot_Manjaro_2021-09-27_20:37:03](https://user-images.githubusercontent.com/6171637/134966210-53a1d3fb-e522-4033-9b89-91bcfc2d4b3e.png)

The visual style is subject to discussion. The trouble is that selection hides information about availability of actions