### PR TITLE
Remove unused fdupes from spec

### DIFF
--- a/rpm/qtquickcontrols-nemo.spec
+++ b/rpm/qtquickcontrols-nemo.spec
@@ -9,7 +9,6 @@ Source0:    %{name}-%{version}.tar.xz
 BuildRequires:  pkgconfig(Qt5Core)
 BuildRequires:  pkgconfig(Qt5Qml)
 BuildRequires:  pkgconfig(Qt5Quick)
-BuildRequires:  fdupes
 
 Requires:   qt5-qtquickcontrols
 Requires:   qt5-qtgraphicaleffects


### PR DESCRIPTION
It's not mentioned anywhere else in the repository.